### PR TITLE
refactor: 修改物料选择组件及关联视图文案

### DIFF
--- a/src/components/Material/MaterialSelect.vue
+++ b/src/components/Material/MaterialSelect.vue
@@ -178,7 +178,7 @@ const { queryParams } = toRefs(data);
 function getTreeSelect() {
   listMaterialCategory().then((response) => {
     materialCategoryOptions.value = [];
-    const data = { id: 0, name: '顶级节点', children: [] };
+    const data = { id: 0, name: '分类', children: [] };
     data.children = proxy.handleTree(response.data, 'id', 'parentId');
     materialCategoryOptions.value.push(data);
   });
@@ -222,7 +222,7 @@ function handleSelect(row) {
     selectionList.value = [];
     selectionList.value.push(row);
   }
-  emits('onSelected', row);
+  emits('onSelected', selectionList.value);
 }
 
 function cancel() {

--- a/src/views/material/materialCategory/index.vue
+++ b/src/views/material/materialCategory/index.vue
@@ -143,7 +143,7 @@ function getList() {
 function getTreeselect() {
   listMaterialCategory().then((response) => {
     materialCategoryOptions.value = [];
-    const data = { id: 0, name: '顶级节点', children: [] };
+    const data = { id: 0, name: '分类', children: [] };
     data.children = proxy.handleTree(response.data, 'id', 'parentId');
     materialCategoryOptions.value.push(data);
   });

--- a/src/views/material/materialInfo/index.vue
+++ b/src/views/material/materialInfo/index.vue
@@ -116,10 +116,6 @@
                 >
               </el-col>
 
-              <el-col :span="1.5">
-                <el-button type="warning" plain icon="Download" @click="open1 = true">打开</el-button>
-              </el-col>
-
               <right-toolbar v-model:show-search="showSearch" @query-table="getList"></right-toolbar>
             </el-row>
 
@@ -224,8 +220,6 @@
         </div>
       </template>
     </el-dialog>
-
-    <material-select :open="open1" @on-cancel="open1 = false"></material-select>
   </div>
 </template>
 
@@ -244,11 +238,8 @@ import {
 } from '@/api/material/materialInfo';
 import useAppStore from '@/store/modules/app';
 
-import MaterialSelect from '../../../components/Material/MaterialSelect.vue';
-
 const { proxy } = getCurrentInstance();
 const { material_type } = proxy.useDict('material_type');
-const open1 = ref(false);
 const appStore = useAppStore();
 const materialInfoList = ref([]);
 const materialCategoryOptions = ref([]);
@@ -287,7 +278,7 @@ const { queryParams, form, rules } = toRefs(data);
 function getTreeSelect() {
   listMaterialCategory().then((response) => {
     materialCategoryOptions.value = [];
-    const data = { id: 0, name: '顶级节点', children: [] };
+    const data = { id: 0, name: '分类', children: [] };
     data.children = proxy.handleTree(response.data, 'id', 'parentId');
     materialCategoryOptions.value.push(data);
   });


### PR DESCRIPTION
<details>
  <summary>修改物料选择组件及关联视图中"顶级节点"为"分类"，并调整事件参数传递方式</summary>
  1. 将MaterialSelect组件的顶级节点名称从"顶级节点"改为"分类"
  2. 修正onSelected事件参数传递逻辑，改为传递selectionList.value
  3. 同步更新materialCategory/index.vue中的对应文案
  4. 移除materialInfo/index.vue中未使用的打开按钮及关联代码 </details>